### PR TITLE
러닝 스케줄 기능 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'com.google.code.gson:gson:2.7'
 
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/runningduk/unirun/api/controller/CalendarController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/CalendarController.java
@@ -1,0 +1,52 @@
+package com.runningduk.unirun.api.controller;
+
+import com.runningduk.unirun.api.response.RunningSchedulesGetRes;
+import com.runningduk.unirun.api.service.RunningScheduleService;
+import com.runningduk.unirun.domain.entity.RunningSchedule;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/calendar")
+public class CalendarController {
+    private final RunningScheduleService runningScheduleService;
+
+    HashMap<String, Object> result;
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @GetMapping("/running-schedules")
+    public ResponseEntity<Map<String, Object>> getRunningSchedules() {
+        try {
+            result = new HashMap<>();
+
+            List<RunningSchedule> runningScheduleList = runningScheduleService.getRunningScheduleList();
+            List<RunningSchedulesGetRes> resList = new ArrayList<>();
+            for (RunningSchedule runningSchedule : runningScheduleList) {
+                resList.add(new RunningSchedulesGetRes(runningSchedule));
+            }
+
+            result.put("runningScheduleList", resList);
+
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            log.error("Failed to fetch running schedules", e);
+
+            result.put("error", "러닝 타입 조회에 실패하였습니다.");
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
+        }
+    }
+}

--- a/src/main/java/com/runningduk/unirun/api/controller/CalendarController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/CalendarController.java
@@ -21,8 +21,8 @@ import java.util.*;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping
-public class RunningScheduleController {
+@RequestMapping("/calendar")
+public class CalendarController {
     private final RunningScheduleService runningScheduleService;
     private final AttendanceService attendanceService;
 
@@ -173,7 +173,7 @@ public class RunningScheduleController {
 
             attendanceService.attendRunningSchedule(runningScheduleId, userId);
 
-            result.put("message", "러닝 스케줄 참석에 성공하였습니다.");
+            result.put("message", "러닝 스케줄 참여에 성공하였습니다.");
 
             return ResponseEntity.ok(result);
         } catch (NoSuchRunningScheduleException e) {
@@ -210,7 +210,7 @@ public class RunningScheduleController {
 
             attendanceService.unattendRunningSchedule(runningScheduleId, userId);
 
-            result.put("message", "러닝 취소에 성공하였습니다.");
+            result.put("message", "러닝 스케줄 참여 취소에 성공하였습니다.");
 
             return ResponseEntity.ok(result);
         } catch (NoSuchRunningScheduleException e) {

--- a/src/main/java/com/runningduk/unirun/api/controller/CalendarController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/CalendarController.java
@@ -3,12 +3,15 @@ package com.runningduk.unirun.api.controller;
 import com.runningduk.unirun.api.response.RunningSchedulesGetRes;
 import com.runningduk.unirun.api.service.RunningScheduleService;
 import com.runningduk.unirun.domain.entity.RunningSchedule;
+import com.runningduk.unirun.exceptions.NoSuchRunningScheduleException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -45,6 +48,31 @@ public class CalendarController {
             log.error("Failed to fetch running schedules", e);
 
             result.put("error", "러닝 타입 조회에 실패하였습니다.");
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
+        }
+    }
+
+    @GetMapping("/running-schedule/{runningScheduleId}")
+    public ResponseEntity<Map<String, Object>> getRunningSchedule(@PathVariable int runningScheduleId) {
+        try {
+            result = new HashMap<>();
+
+            RunningSchedule runningSchedule = runningScheduleService.getRunningScheduleById(runningScheduleId);
+
+            result.put("runningSchedule", runningSchedule);
+
+            return ResponseEntity.ok(result);
+        } catch (NoSuchRunningScheduleException e) {
+            log.error("Failed to fetch running schedule for running_schedule_id " + runningScheduleId, e);
+
+            result.put("error", e.getMessage());
+
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+        } catch (Exception e) {
+            log.error("Failed to fetch running schedule for running_schedule_id " + runningScheduleId, e);
+
+            result.put("error", "An internal server error occurred. Please try again later.");
 
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
         }

--- a/src/main/java/com/runningduk/unirun/api/controller/RunningScheduleController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/RunningScheduleController.java
@@ -53,45 +53,6 @@ public class RunningScheduleController {
         }
     }
 
-    @GetMapping("/running-schedule/{runningScheduleId}")
-    public ResponseEntity<Map<String, Object>> getRunningSchedule(@PathVariable int runningScheduleId, HttpSession session) {
-        try {
-            result = new HashMap<>();
-
-            RunningSchedule runningSchedule = runningScheduleService.getRunningScheduleById(runningScheduleId);
-
-            int daysUntilRunning = runningScheduleService.checkDaysLeft(runningSchedule.getRunningDate());
-
-            String userId = (String) session.getAttribute("userId");
-
-            if (userId == null) {
-                result.put("error", "Login is required.");
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(result);
-            }
-            boolean isParticipant = (runningScheduleService.isUserCreater(runningSchedule, userId) || attendanceService.isUserParticipant(runningScheduleId, userId));
-
-            System.out.println(isParticipant);
-
-            result.put("runningSchedule", runningSchedule);
-            result.put("daysUntilRunning", daysUntilRunning);
-            result.put("participant", isParticipant);
-
-            return ResponseEntity.ok(result);
-        } catch (NoSuchRunningScheduleException e) {
-            log.error("Failed to fetch running schedule for running_schedule_id " + runningScheduleId, e);
-
-            result.put("error", e.getMessage());
-
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
-        } catch (Exception e) {
-            log.error("Failed to fetch running schedule for running_schedule_id " + runningScheduleId, e);
-
-            result.put("error", "An internal server error occurred. Please try again later.");
-
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
-        }
-    }
-
     @GetMapping("/my-running-schedules")
     public ResponseEntity<Map<String, Object>> getMyRunningSchedules(HttpSession session) {
         try {

--- a/src/main/java/com/runningduk/unirun/api/controller/RunningScheduleController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/RunningScheduleController.java
@@ -150,7 +150,7 @@ public class RunningScheduleController {
 
             result.put("error", e.getMessage());
 
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(result);
         } catch (Exception e) {
             log.error("Failed to delete running schedule for running_schedule_id " + runningScheduleId, e);
 
@@ -181,15 +181,15 @@ public class RunningScheduleController {
 
             result.put("error", e.getMessage());
 
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(result);
         } catch (DuplicateAttendingException e) {
             log.error("Failed to attend running schedule for running_schedule_id " + runningScheduleId, e);
 
             result.put("error", e.getMessage());
 
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(result);
         } catch (Exception e) {
-            log.error("Failed to delete running schedule for running_schedule_id " + runningScheduleId, e);
+            log.error("Failed to attend running schedule for running_schedule_id " + runningScheduleId, e);
 
             result.put("error", "An internal server error occurred. Please try again later.");
 
@@ -197,7 +197,7 @@ public class RunningScheduleController {
         }
     }
 
-    @PostMapping("/running-schedule/{runningScheduleId}/unattend")
+    @DeleteMapping("/running-schedule/{runningScheduleId}/unattend")
     public ResponseEntity<Map<String, Object>> handleUnattendRunningSchedule(@PathVariable(name="runningScheduleId") int runningScheduleId, HttpSession httpSession) {
         try {
             result = new HashMap<>();

--- a/src/main/java/com/runningduk/unirun/api/controller/RunningScheduleController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/RunningScheduleController.java
@@ -1,11 +1,9 @@
 package com.runningduk.unirun.api.controller;
 
 import com.runningduk.unirun.api.response.MyRunningSchedulesGetRes;
-import com.runningduk.unirun.api.response.RunningSchedulesGetRes;
 import com.runningduk.unirun.api.service.AttendanceService;
 import com.runningduk.unirun.api.service.RunningScheduleService;
 import com.runningduk.unirun.domain.entity.RunningSchedule;
-import com.runningduk.unirun.exceptions.NoSuchRunningScheduleException;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -14,10 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.sql.Date;
+import java.util.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -29,6 +25,25 @@ public class RunningScheduleController {
     HashMap<String, Object> result;
 
     private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @GetMapping("/running-schedules/monthly")
+    public ResponseEntity<Map<String, Object>> handleGetRunningSchedulesMonthly(@RequestParam(name="year") int year, @RequestParam(name="month") int month) {
+        try {
+            result = new HashMap<>();
+
+            List<Date> runningDateList = runningScheduleService.getRunningScheduleMonthly(year, month);
+
+            result.put("runningDates", runningDateList);
+
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            log.error("Failed to fetch monthly running schedules.", e);
+
+            result.put("error", "An internal server error occurred. Please try again later.");
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
+        }
+    }
 
     @GetMapping("/my-running-schedules")
     public ResponseEntity<Map<String, Object>> getMyRunningSchedules(HttpSession session) {

--- a/src/main/java/com/runningduk/unirun/api/controller/RunningScheduleController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/RunningScheduleController.java
@@ -30,29 +30,6 @@ public class RunningScheduleController {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    @GetMapping("/running-schedules")
-    public ResponseEntity<Map<String, Object>> getRunningSchedules() {
-        try {
-            result = new HashMap<>();
-
-            List<RunningSchedule> runningScheduleList = runningScheduleService.getRunningScheduleList();
-            List<RunningSchedulesGetRes> resList = new ArrayList<>();
-            for (RunningSchedule runningSchedule : runningScheduleList) {
-                resList.add(new RunningSchedulesGetRes(runningSchedule));
-            }
-
-            result.put("runningScheduleList", resList);
-
-            return ResponseEntity.ok(result);
-        } catch (Exception e) {
-            log.error("Failed to fetch running schedules", e);
-
-            result.put("error", "러닝 타입 조회에 실패하였습니다.");
-
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
-        }
-    }
-
     @GetMapping("/my-running-schedules")
     public ResponseEntity<Map<String, Object>> getMyRunningSchedules(HttpSession session) {
         try {

--- a/src/main/java/com/runningduk/unirun/api/controller/RunningScheduleController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/RunningScheduleController.java
@@ -109,10 +109,12 @@ public class RunningScheduleController {
             List<RunningSchedule> userCreatedSchedules = runningScheduleService.getRunningScheduleListByUserId(userId);
 
             for (RunningSchedule runningSchedule : userCreatedSchedules) {
+                int daysUtilRunningDate = runningScheduleService.checkDaysLeft(runningSchedule.getRunningDate());
                 MyRunningSchedulesGetRes res = MyRunningSchedulesGetRes.builder()
                                 .runningSchedule(runningSchedule)
                                 .isCreater(true)
                                 .isParticipant(false)
+                                .daysUntilRunningDate(daysUtilRunningDate)
                                 .build();
                 resList.add(res);
             }
@@ -120,10 +122,12 @@ public class RunningScheduleController {
             List<RunningSchedule> attendedSchedule = attendanceService.getRunningScheduleListByUserId(userId);
 
             for (RunningSchedule runningSchedule : attendedSchedule) {
+                int daysUtilRunningDate = runningScheduleService.checkDaysLeft(runningSchedule.getRunningDate());
                 MyRunningSchedulesGetRes res = MyRunningSchedulesGetRes.builder()
                         .runningSchedule(runningSchedule)
                         .isCreater(false)
                         .isParticipant(true)
+                        .daysUntilRunningDate(daysUtilRunningDate)
                         .build();
                 resList.add(res);
             }

--- a/src/main/java/com/runningduk/unirun/api/controller/RunningScheduleController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/RunningScheduleController.java
@@ -21,8 +21,8 @@ import java.util.Map;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/calendar")
-public class CalendarController {
+@RequestMapping
+public class RunningScheduleController {
     private final RunningScheduleService runningScheduleService;
     private final AttendanceService attendanceService;
 

--- a/src/main/java/com/runningduk/unirun/api/controller/RunningScheduleController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/RunningScheduleController.java
@@ -45,6 +45,28 @@ public class RunningScheduleController {
         }
     }
 
+    @GetMapping("/running-schedules/daily")
+    public ResponseEntity<Map<String, Object>> handleGetRunningSchedulesDaily(
+            @RequestParam(name="year") int year,
+            @RequestParam(name="month") int month,
+            @RequestParam(name="day") int day) {
+        try {
+            result = new HashMap<>();
+
+            List<RunningSchedule> runningScheduleList = runningScheduleService.getRunningScheduleByDate(year, month, day);
+
+            result.put("runningSchedules", runningScheduleList);
+
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            log.error("Failed to fetch daily running schedules.", e);
+
+            result.put("error", "An internal server error occurred. Please try again later.");
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
+        }
+    }
+
     @GetMapping("/my-running-schedules")
     public ResponseEntity<Map<String, Object>> getMyRunningSchedules(HttpSession session) {
         try {

--- a/src/main/java/com/runningduk/unirun/api/request/RunningSchedulePostReq.java
+++ b/src/main/java/com/runningduk/unirun/api/request/RunningSchedulePostReq.java
@@ -1,0 +1,75 @@
+package com.runningduk.unirun.api.request;
+
+import com.runningduk.unirun.domain.entity.RunningSchedule;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@ToString
+public class RunningSchedulePostReq {
+    @NotBlank(message = "Type is required")
+    private String type;
+
+    @NotBlank(message = "Title is required")
+    private String title;
+
+    @NotBlank(message = "Creew is required")
+    private String crew;
+
+    @NotBlank(message = "Date is required")
+    @Pattern(regexp = "^\\d{4}\\.\\d{2}\\.\\d{2}$", message = "Date must be in yyyy.MM.dd format")
+    private String date;
+
+    @NotBlank(message = "Start time is required")
+    @Pattern(regexp = "^\\d{2}:\\d{2}$", message = "Start time must be in hh:mm format")
+    private String startTime;
+
+    @NotBlank(message = "End time is required")
+    @Pattern(regexp = "^\\d{2}:\\d{2}$", message = "End time must be in hh:mm format")
+    private String endTime;
+
+    @NotBlank(message = "Place is required")
+    private String place;
+
+    @NotBlank(message = "Audience type is required")
+    private String audienceType;
+
+    public RunningSchedule toEntity() {
+        String formattedDate = date.replace(".", "-");
+
+        String formattedStartTime = startTime + ":00";
+        String formattedEndTime = endTime + ":00";
+
+        RunningSchedule runningSchedule = RunningSchedule.builder()
+                .type(type)
+                .title(title)
+                .runningCrew(crew)
+                .runningDate(java.sql.Date.valueOf(formattedDate))
+                .startTime(java.sql.Time.valueOf(formattedStartTime))
+                .endTime(java.sql.Time.valueOf(formattedEndTime))
+                .place(place)
+                .audienceType(audienceType)
+                .build();
+
+        return runningSchedule;
+    }
+
+    public void validateDateAndTime() {
+        LocalDate todayDate = LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+        if (todayDate.isBefore(LocalDate.now())) {
+            throw new IllegalArgumentException("The date must be today or a future date.");
+        }
+
+        LocalTime start = LocalTime.parse(startTime, DateTimeFormatter.ofPattern("HH:mm"));
+        LocalTime end = LocalTime.parse(endTime, DateTimeFormatter.ofPattern("HH:mm"));
+        if (!start.isBefore(end)) {
+            throw new IllegalArgumentException("Start time must be before end time.");
+        }
+    }
+}

--- a/src/main/java/com/runningduk/unirun/api/response/MyRunningSchedulesGetRes.java
+++ b/src/main/java/com/runningduk/unirun/api/response/MyRunningSchedulesGetRes.java
@@ -1,0 +1,14 @@
+package com.runningduk.unirun.api.response;
+
+import com.runningduk.unirun.domain.entity.RunningSchedule;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyRunningSchedulesGetRes {
+    private final RunningSchedule runningSchedule;
+    private final boolean isCreater;
+    private final boolean isParticipant;
+}

--- a/src/main/java/com/runningduk/unirun/api/response/MyRunningSchedulesGetRes.java
+++ b/src/main/java/com/runningduk/unirun/api/response/MyRunningSchedulesGetRes.java
@@ -11,4 +11,5 @@ public class MyRunningSchedulesGetRes {
     private final RunningSchedule runningSchedule;
     private final boolean isCreater;
     private final boolean isParticipant;
+    private final int daysUntilRunningDate;
 }

--- a/src/main/java/com/runningduk/unirun/api/response/RunningSchedulesGetRes.java
+++ b/src/main/java/com/runningduk/unirun/api/response/RunningSchedulesGetRes.java
@@ -1,0 +1,21 @@
+package com.runningduk.unirun.api.response;
+
+import com.runningduk.unirun.domain.entity.RunningSchedule;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.sql.Date;
+
+@Getter
+@AllArgsConstructor
+public class RunningSchedulesGetRes {
+    private final int runningScheduleId;
+    private final String type;
+    private final Date runningDate;
+
+    public RunningSchedulesGetRes(RunningSchedule runningSchedule) {
+        this.runningScheduleId = runningSchedule.getRunningScheduleId();
+        this.type = runningSchedule.getType();
+        this.runningDate = runningSchedule.getRunningDate();
+    }
+}

--- a/src/main/java/com/runningduk/unirun/api/service/AttendanceService.java
+++ b/src/main/java/com/runningduk/unirun/api/service/AttendanceService.java
@@ -2,8 +2,10 @@ package com.runningduk.unirun.api.service;
 
 import com.runningduk.unirun.domain.entity.Attendance;
 import com.runningduk.unirun.domain.entity.RunningSchedule;
+import com.runningduk.unirun.exceptions.CreatorCannotCancelException;
 import com.runningduk.unirun.exceptions.DuplicateAttendingException;
 import com.runningduk.unirun.exceptions.NoSuchRunningScheduleException;
+import com.runningduk.unirun.exceptions.NotParticipatingException;
 
 import java.util.List;
 
@@ -13,4 +15,6 @@ public interface AttendanceService {
     boolean isUserParticipant(int runningScheduleId, String userId);
 
     void attendRunningSchedule(int runningScheduleId, String userId) throws NoSuchRunningScheduleException, DuplicateAttendingException;
+
+    void unattendRunningSchedule(int runningScheduleId, String userId) throws NoSuchRunningScheduleException, CreatorCannotCancelException, NotParticipatingException;
 }

--- a/src/main/java/com/runningduk/unirun/api/service/AttendanceService.java
+++ b/src/main/java/com/runningduk/unirun/api/service/AttendanceService.java
@@ -1,6 +1,9 @@
 package com.runningduk.unirun.api.service;
 
+import com.runningduk.unirun.domain.entity.Attendance;
 import com.runningduk.unirun.domain.entity.RunningSchedule;
+import com.runningduk.unirun.exceptions.DuplicateAttendingException;
+import com.runningduk.unirun.exceptions.NoSuchRunningScheduleException;
 
 import java.util.List;
 
@@ -8,4 +11,6 @@ public interface AttendanceService {
     public List<RunningSchedule> getRunningScheduleListByUserId(String userId);
 
     boolean isUserParticipant(int runningScheduleId, String userId);
+
+    void attendRunningSchedule(int runningScheduleId, String userId) throws NoSuchRunningScheduleException, DuplicateAttendingException;
 }

--- a/src/main/java/com/runningduk/unirun/api/service/AttendanceService.java
+++ b/src/main/java/com/runningduk/unirun/api/service/AttendanceService.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface AttendanceService {
     public List<RunningSchedule> getRunningScheduleListByUserId(String userId);
+
+    boolean isUserParticipant(int runningScheduleId, String userId);
 }

--- a/src/main/java/com/runningduk/unirun/api/service/AttendanceServiceImpl.java
+++ b/src/main/java/com/runningduk/unirun/api/service/AttendanceServiceImpl.java
@@ -1,5 +1,6 @@
 package com.runningduk.unirun.api.service;
 
+import com.runningduk.unirun.common.DateUtils;
 import com.runningduk.unirun.domain.entity.Attendance;
 import com.runningduk.unirun.domain.entity.RunningSchedule;
 import com.runningduk.unirun.domain.repository.AttendanceRepository;
@@ -7,8 +8,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +25,10 @@ public class AttendanceServiceImpl implements AttendanceService {
             runningScheduleList.add(attendance.getRunningSchedule());
         }
 
-        return runningScheduleList;
+        LocalDate today = LocalDate.now();
+        return runningScheduleList.stream()
+                .filter(schedule -> !DateUtils.convertToLocalDate(schedule.getRunningDate()).isBefore(today))
+                .collect(Collectors.toList());
     }
 
     public boolean isUserParticipant(int runningScheduleId, String userId) {

--- a/src/main/java/com/runningduk/unirun/api/service/AttendanceServiceImpl.java
+++ b/src/main/java/com/runningduk/unirun/api/service/AttendanceServiceImpl.java
@@ -24,4 +24,8 @@ public class AttendanceServiceImpl implements AttendanceService {
 
         return runningScheduleList;
     }
+
+    public boolean isUserParticipant(int runningScheduleId, String userId) {
+        return attendanceRepository.existsByRunningScheduleIdAndUserId(runningScheduleId, userId);
+    }
 }

--- a/src/main/java/com/runningduk/unirun/api/service/AttendanceServiceImpl.java
+++ b/src/main/java/com/runningduk/unirun/api/service/AttendanceServiceImpl.java
@@ -4,8 +4,10 @@ import com.runningduk.unirun.common.DateUtils;
 import com.runningduk.unirun.domain.entity.Attendance;
 import com.runningduk.unirun.domain.entity.RunningSchedule;
 import com.runningduk.unirun.domain.repository.AttendanceRepository;
+import com.runningduk.unirun.exceptions.CreatorCannotCancelException;
 import com.runningduk.unirun.exceptions.DuplicateAttendingException;
 import com.runningduk.unirun.exceptions.NoSuchRunningScheduleException;
+import com.runningduk.unirun.exceptions.NotParticipatingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -55,5 +57,18 @@ public class AttendanceServiceImpl implements AttendanceService {
         System.out.println("attendance service - new attendance : " + newAttendance);
 
         attendanceRepository.save(newAttendance);
+    }
+
+    public void unattendRunningSchedule(int runningScheduleId, String userId)
+            throws NoSuchRunningScheduleException, CreatorCannotCancelException, NotParticipatingException {
+        RunningSchedule runningSchedule = runningScheduleService.getRunningScheduleById(runningScheduleId);
+
+        if (runningSchedule.getUserId().equals(userId)) {
+            throw new CreatorCannotCancelException();
+        } else if (!attendanceRepository.existsByRunningScheduleIdAndUserId(runningScheduleId, userId)) {
+            throw new NotParticipatingException(String.valueOf(runningScheduleId));
+        }
+
+        attendanceRepository.deleteByRunningScheduleIdAndUserId(runningScheduleId, userId);
     }
 }

--- a/src/main/java/com/runningduk/unirun/api/service/RunningScheduleService.java
+++ b/src/main/java/com/runningduk/unirun/api/service/RunningScheduleService.java
@@ -1,6 +1,7 @@
 package com.runningduk.unirun.api.service;
 
 import com.runningduk.unirun.domain.entity.RunningSchedule;
+import com.runningduk.unirun.exceptions.NoSuchRunningScheduleException;
 
 import java.util.List;
 
@@ -8,4 +9,6 @@ public interface RunningScheduleService {
     public List<RunningSchedule> getRunningScheduleListByUserId(String userId);
 
     public List<RunningSchedule> getRunningScheduleList();
+
+    RunningSchedule getRunningScheduleById(int runningScheduleId) throws NoSuchRunningScheduleException;
 }

--- a/src/main/java/com/runningduk/unirun/api/service/RunningScheduleService.java
+++ b/src/main/java/com/runningduk/unirun/api/service/RunningScheduleService.java
@@ -22,4 +22,6 @@ public interface RunningScheduleService {
     List<RunningSchedule> getRunningScheduleByDate(int year, int month, int day);
 
     void deleteRunningSchedule(int runningScheduleId) throws NoSuchRunningScheduleException;
+
+    void addRunningSchedule(RunningSchedule runningSchedule);
 }

--- a/src/main/java/com/runningduk/unirun/api/service/RunningScheduleService.java
+++ b/src/main/java/com/runningduk/unirun/api/service/RunningScheduleService.java
@@ -18,4 +18,6 @@ public interface RunningScheduleService {
     boolean isUserCreater(RunningSchedule runningSchedule, String userId);
 
     List<Date> getRunningScheduleMonthly(int year, int month);
+
+    List<RunningSchedule> getRunningScheduleByDate(int year, int month, int day);
 }

--- a/src/main/java/com/runningduk/unirun/api/service/RunningScheduleService.java
+++ b/src/main/java/com/runningduk/unirun/api/service/RunningScheduleService.java
@@ -20,4 +20,6 @@ public interface RunningScheduleService {
     List<Date> getRunningScheduleMonthly(int year, int month);
 
     List<RunningSchedule> getRunningScheduleByDate(int year, int month, int day);
+
+    void deleteRunningSchedule(int runningScheduleId) throws NoSuchRunningScheduleException;
 }

--- a/src/main/java/com/runningduk/unirun/api/service/RunningScheduleService.java
+++ b/src/main/java/com/runningduk/unirun/api/service/RunningScheduleService.java
@@ -16,4 +16,6 @@ public interface RunningScheduleService {
     int checkDaysLeft(Date runningDate);
 
     boolean isUserCreater(RunningSchedule runningSchedule, String userId);
+
+    List<Date> getRunningScheduleMonthly(int year, int month);
 }

--- a/src/main/java/com/runningduk/unirun/api/service/RunningScheduleService.java
+++ b/src/main/java/com/runningduk/unirun/api/service/RunningScheduleService.java
@@ -3,6 +3,7 @@ package com.runningduk.unirun.api.service;
 import com.runningduk.unirun.domain.entity.RunningSchedule;
 import com.runningduk.unirun.exceptions.NoSuchRunningScheduleException;
 
+import java.sql.Date;
 import java.util.List;
 
 public interface RunningScheduleService {
@@ -11,4 +12,8 @@ public interface RunningScheduleService {
     public List<RunningSchedule> getRunningScheduleList();
 
     RunningSchedule getRunningScheduleById(int runningScheduleId) throws NoSuchRunningScheduleException;
+
+    int checkDaysLeft(Date runningDate);
+
+    boolean isUserCreater(RunningSchedule runningSchedule, String userId);
 }

--- a/src/main/java/com/runningduk/unirun/api/service/RunningScheduleService.java
+++ b/src/main/java/com/runningduk/unirun/api/service/RunningScheduleService.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface RunningScheduleService {
     public List<RunningSchedule> getRunningScheduleListByUserId(String userId);
+
+    public List<RunningSchedule> getRunningScheduleList();
 }

--- a/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
+++ b/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
@@ -1,6 +1,7 @@
 package com.runningduk.unirun.api.service;
 
 import com.runningduk.unirun.api.controller.RunningTypeController;
+import com.runningduk.unirun.common.DateUtils;
 import com.runningduk.unirun.domain.entity.RunningSchedule;
 import com.runningduk.unirun.domain.repository.RunningScheduleRepository;
 import com.runningduk.unirun.exceptions.NoSuchRunningScheduleException;
@@ -11,8 +12,10 @@ import java.sql.Date;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -20,7 +23,11 @@ public class RunningScheduleServiceImpl implements RunningScheduleService {
     private final RunningScheduleRepository runningScheduleRepository;
 
     public List<RunningSchedule> getRunningScheduleListByUserId(String userId) {
-        return runningScheduleRepository.findByUserId(userId);
+        List<RunningSchedule> runningScheduleList = runningScheduleRepository.findByUserId(userId);
+        LocalDate today = LocalDate.now();
+        return runningScheduleList.stream()
+                .filter(schedule -> !DateUtils.convertToLocalDate(schedule.getRunningDate()).isBefore(today))
+                .collect(Collectors.toList());
     }
 
     public List<RunningSchedule> getRunningScheduleList() {

--- a/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
+++ b/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
@@ -7,6 +7,10 @@ import com.runningduk.unirun.exceptions.NoSuchRunningScheduleException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,5 +35,17 @@ public class RunningScheduleServiceImpl implements RunningScheduleService {
         } else {
             throw new NoSuchRunningScheduleException(runningScheduleId);
         }
+    }
+
+    public int checkDaysLeft(Date runningDate) {
+        LocalDate eventDate = runningDate.toLocalDate();
+        LocalDate today = LocalDate.now(ZoneId.systemDefault());    // 오늘 날짜 가져오기
+
+        // 오늘부터 이벤트 날짜까지 남은 일수 계산
+        return (int) ChronoUnit.DAYS.between(today, eventDate);
+    }
+
+    public boolean isUserCreater(RunningSchedule runningSchedule, String userId) {
+        return (runningSchedule.getUserId().equals(userId));
     }
 }

--- a/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
+++ b/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
@@ -1,6 +1,5 @@
 package com.runningduk.unirun.api.service;
 
-import com.runningduk.unirun.api.controller.RunningTypeController;
 import com.runningduk.unirun.common.DateUtils;
 import com.runningduk.unirun.domain.entity.RunningSchedule;
 import com.runningduk.unirun.domain.repository.RunningScheduleRepository;
@@ -11,6 +10,7 @@ import org.springframework.stereotype.Service;
 import java.sql.Date;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
@@ -54,5 +54,19 @@ public class RunningScheduleServiceImpl implements RunningScheduleService {
 
     public boolean isUserCreater(RunningSchedule runningSchedule, String userId) {
         return (runningSchedule.getUserId().equals(userId));
+    }
+
+    public List<Date> getRunningScheduleMonthly(int year, int month) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String dateStr = year + "-" + String.format("%02d", month) + "-" + "01";
+
+        LocalDate date = LocalDate.parse(dateStr, formatter);
+        LocalDate firstDateOfMonth = date.withDayOfMonth(1);
+        LocalDate lastDateOfMonth = date.withDayOfMonth(date.lengthOfMonth());
+
+        Date firstDateParam = java.sql.Date.valueOf(firstDateOfMonth);
+        Date lastDateParam = java.sql.Date.valueOf(lastDateOfMonth);
+
+        return runningScheduleRepository.findDistinctRunningDatesByMonth(firstDateParam, lastDateParam);
     }
 }

--- a/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
+++ b/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
@@ -3,10 +3,12 @@ package com.runningduk.unirun.api.service;
 import com.runningduk.unirun.api.controller.RunningTypeController;
 import com.runningduk.unirun.domain.entity.RunningSchedule;
 import com.runningduk.unirun.domain.repository.RunningScheduleRepository;
+import com.runningduk.unirun.exceptions.NoSuchRunningScheduleException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,5 +21,15 @@ public class RunningScheduleServiceImpl implements RunningScheduleService {
 
     public List<RunningSchedule> getRunningScheduleList() {
         return runningScheduleRepository.findAll();
+    }
+
+    public RunningSchedule getRunningScheduleById(int runningScheduleId) throws NoSuchRunningScheduleException {
+        Optional<RunningSchedule> result = runningScheduleRepository.findById(runningScheduleId);
+
+        if (result.isPresent()) {
+            return result.get();
+        } else {
+            throw new NoSuchRunningScheduleException(runningScheduleId);
+        }
     }
 }

--- a/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
+++ b/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
@@ -79,4 +79,14 @@ public class RunningScheduleServiceImpl implements RunningScheduleService {
 
         return runningScheduleRepository.findRunningScheduleByRunningDate(dateParam);
     }
+
+    public void deleteRunningSchedule(int runningScheduleId) throws NoSuchRunningScheduleException {
+        Optional<RunningSchedule> result = runningScheduleRepository.findById(runningScheduleId);
+
+        if (!result.isPresent()) {
+            throw new NoSuchRunningScheduleException(runningScheduleId);
+        }
+
+        runningScheduleRepository.deleteById(runningScheduleId);
+    }
 }

--- a/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
+++ b/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
@@ -69,4 +69,14 @@ public class RunningScheduleServiceImpl implements RunningScheduleService {
 
         return runningScheduleRepository.findDistinctRunningDatesByMonth(firstDateParam, lastDateParam);
     }
+
+    public List<RunningSchedule> getRunningScheduleByDate(int year, int month, int day) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String dateStr = year + "-" + String.format("%02d", month) + "-" + String.format("%02d", day);
+
+        LocalDate date = LocalDate.parse(dateStr, formatter);
+        Date dateParam = java.sql.Date.valueOf(date);
+
+        return runningScheduleRepository.findRunningScheduleByRunningDate(dateParam);
+    }
 }

--- a/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
+++ b/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
@@ -89,4 +89,8 @@ public class RunningScheduleServiceImpl implements RunningScheduleService {
 
         runningScheduleRepository.deleteById(runningScheduleId);
     }
+
+    public void addRunningSchedule(RunningSchedule runningSchedule) {
+        runningScheduleRepository.save(runningSchedule);
+    }
 }

--- a/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
+++ b/src/main/java/com/runningduk/unirun/api/service/RunningScheduleServiceImpl.java
@@ -16,4 +16,8 @@ public class RunningScheduleServiceImpl implements RunningScheduleService {
     public List<RunningSchedule> getRunningScheduleListByUserId(String userId) {
         return runningScheduleRepository.findByUserId(userId);
     }
+
+    public List<RunningSchedule> getRunningScheduleList() {
+        return runningScheduleRepository.findAll();
+    }
 }

--- a/src/main/java/com/runningduk/unirun/common/DateUtils.java
+++ b/src/main/java/com/runningduk/unirun/common/DateUtils.java
@@ -1,0 +1,14 @@
+package com.runningduk.unirun.common;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+public class DateUtils {
+    public static LocalDate convertToLocalDate(Date dateToConvert) {
+//        return dateToConvert.toInstant()
+//                .atZone(ZoneId.systemDefault())
+//                .toLocalDate();
+        return dateToConvert.toLocalDate();
+    }
+}

--- a/src/main/java/com/runningduk/unirun/domain/entity/Attendance.java
+++ b/src/main/java/com/runningduk/unirun/domain/entity/Attendance.java
@@ -18,13 +18,13 @@ public class Attendance {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int attendanceId;
 
-    @Column(name="running_schedule_id")
+    @Column(name="running_schedule_id", insertable = false, updatable = false)
     private int runningScheduleId;
 
     @Column(name="user_id")
     private String userId;
 
     @ManyToOne
-    @JoinColumn(name="sessionId")
+    @JoinColumn(name="running_schedule_id", insertable = true, updatable = true)
     private RunningSchedule runningSchedule;
 }

--- a/src/main/java/com/runningduk/unirun/domain/entity/Attendance.java
+++ b/src/main/java/com/runningduk/unirun/domain/entity/Attendance.java
@@ -1,10 +1,7 @@
 package com.runningduk.unirun.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "attendance")
@@ -12,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class Attendance {
     @Id
     @Column(name="attendance_id")

--- a/src/main/java/com/runningduk/unirun/domain/entity/RunningSchedule.java
+++ b/src/main/java/com/runningduk/unirun/domain/entity/RunningSchedule.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.sql.Date;
+import java.sql.Time;
 
 @Entity
 @Table(name="running_schedule")
@@ -30,10 +31,10 @@ public class RunningSchedule {
     private Date runningDate;
 
     @Column(name="start_time")
-    private String startTime;
+    private Time startTime;
 
     @Column(name="end_time")
-    private String endTime;
+    private Time endTime;
 
     @Column(name="type")
     private String type;

--- a/src/main/java/com/runningduk/unirun/domain/entity/RunningSchedule.java
+++ b/src/main/java/com/runningduk/unirun/domain/entity/RunningSchedule.java
@@ -1,10 +1,7 @@
 package com.runningduk.unirun.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -12,6 +9,7 @@ import java.sql.Time;
 @Entity
 @Table(name="running_schedule")
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/runningduk/unirun/domain/repository/AttendanceRepository.java
+++ b/src/main/java/com/runningduk/unirun/domain/repository/AttendanceRepository.java
@@ -4,6 +4,8 @@ import com.runningduk.unirun.domain.entity.Attendance;
 import com.runningduk.unirun.domain.entity.Gps;
 import com.runningduk.unirun.domain.entity.RunningSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,4 +13,7 @@ import java.util.List;
 @Repository
 public interface AttendanceRepository extends JpaRepository<Attendance, Integer> {
     public List<Attendance> findByUserId(String userId);
+
+    @Query("SELECT CASE WHEN COUNT(a) > 0 THEN true ELSE false END FROM Attendance a WHERE a.runningScheduleId = :runningScheduleId AND a.userId = :userId")
+    boolean existsByRunningScheduleIdAndUserId(@Param("runningScheduleId") int runningScheduleId, @Param("userId") String userId);
 }

--- a/src/main/java/com/runningduk/unirun/domain/repository/AttendanceRepository.java
+++ b/src/main/java/com/runningduk/unirun/domain/repository/AttendanceRepository.java
@@ -3,6 +3,7 @@ package com.runningduk.unirun.domain.repository;
 import com.runningduk.unirun.domain.entity.Attendance;
 import com.runningduk.unirun.domain.entity.Gps;
 import com.runningduk.unirun.domain.entity.RunningSchedule;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,4 +17,7 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Integer>
 
     @Query("SELECT CASE WHEN COUNT(a) > 0 THEN true ELSE false END FROM Attendance a WHERE a.runningScheduleId = :runningScheduleId AND a.userId = :userId")
     boolean existsByRunningScheduleIdAndUserId(@Param("runningScheduleId") int runningScheduleId, @Param("userId") String userId);
+
+    @Transactional
+    void deleteByRunningScheduleIdAndUserId(int runningScheduleId, String userId);
 }

--- a/src/main/java/com/runningduk/unirun/domain/repository/RunningScheduleRepository.java
+++ b/src/main/java/com/runningduk/unirun/domain/repository/RunningScheduleRepository.java
@@ -15,4 +15,6 @@ public interface RunningScheduleRepository extends JpaRepository<RunningSchedule
 
     @Query("SELECT DISTINCT rs.runningDate FROM RunningSchedule rs WHERE rs.runningDate BETWEEN :startDate AND :endDate ORDER BY rs.runningDate")
     public List<Date> findDistinctRunningDatesByMonth(@Param("startDate") Date startDate, @Param("endDate") Date endDate);
+
+    public List<RunningSchedule> findRunningScheduleByRunningDate(Date date);
 }

--- a/src/main/java/com/runningduk/unirun/domain/repository/RunningScheduleRepository.java
+++ b/src/main/java/com/runningduk/unirun/domain/repository/RunningScheduleRepository.java
@@ -1,10 +1,18 @@
 package com.runningduk.unirun.domain.repository;
 
 import com.runningduk.unirun.domain.entity.RunningSchedule;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.sql.Date;
 import java.util.List;
 
-public interface RunningScheduleRepository extends JpaRepository<RunningSchedule, Integer> {
+public interface RunningScheduleRepository extends JpaRepository<RunningSchedule, Integer>, JpaSpecificationExecutor<RunningSchedule> {
     public List<RunningSchedule> findByUserId(String userId);
+
+    @Query("SELECT DISTINCT rs.runningDate FROM RunningSchedule rs WHERE rs.runningDate BETWEEN :startDate AND :endDate ORDER BY rs.runningDate")
+    public List<Date> findDistinctRunningDatesByMonth(@Param("startDate") Date startDate, @Param("endDate") Date endDate);
 }

--- a/src/main/java/com/runningduk/unirun/exceptions/CreatorCannotCancelException.java
+++ b/src/main/java/com/runningduk/unirun/exceptions/CreatorCannotCancelException.java
@@ -1,0 +1,7 @@
+package com.runningduk.unirun.exceptions;
+
+public class CreatorCannotCancelException extends Exception {
+    public CreatorCannotCancelException() {
+        super("The creator of the schedule cannot cancel their own participation.");
+    }
+}

--- a/src/main/java/com/runningduk/unirun/exceptions/DuplicateAttendingException.java
+++ b/src/main/java/com/runningduk/unirun/exceptions/DuplicateAttendingException.java
@@ -1,0 +1,7 @@
+package com.runningduk.unirun.exceptions;
+
+public class DuplicateAttendingException extends Exception {
+    public DuplicateAttendingException(String runningScheduleId) {
+        super("Attendee has already registered for the running schedule with ID: " + runningScheduleId);
+    }
+}

--- a/src/main/java/com/runningduk/unirun/exceptions/NoSuchRunningScheduleException.java
+++ b/src/main/java/com/runningduk/unirun/exceptions/NoSuchRunningScheduleException.java
@@ -1,0 +1,7 @@
+package com.runningduk.unirun.exceptions;
+
+public class NoSuchRunningScheduleException extends Exception {
+    public NoSuchRunningScheduleException(int runningScheduleId) {
+        super("Running schedule with ID " + runningScheduleId + " not found.");
+    }
+}

--- a/src/main/java/com/runningduk/unirun/exceptions/NotParticipatingException.java
+++ b/src/main/java/com/runningduk/unirun/exceptions/NotParticipatingException.java
@@ -1,0 +1,7 @@
+package com.runningduk.unirun.exceptions;
+
+public class NotParticipatingException extends Exception {
+    public NotParticipatingException(String runningScheduleId) {
+        super("You cannot cancel participation because you are not currently participating in the schedule with ID: " + runningScheduleId);
+    }
+}


### PR DESCRIPTION
## 요약 

러닝 스케줄 기능에 사용되는 API 입니다. 
<br><br>

## 작업 내용 
- [x] 월별 러닝 스케줄 날짜 조회 API
  - 연도와 월을 기준으로 러닝 스케줄이 있는 날짜를 반환합니다. 
- [x] 날짜별 러닝 스케줄 조회 API
  - 해당 날짜에 등록된 러닝 스케줄을 전부 반환합니다. 
- [x] 러닝 스케줄 작성 API
  - 러닝 스케줄을 등록합니다. 
  - 이때 유효성 검사를 통해 부정확한 입력을 방지합니다. 
- [x] 러닝 스케줄 삭제 API
  - 러닝 스케줄을 삭제합니다. 
  - 이때 해당 러닝 스케줄 작성자만 삭제할 수 있도록 합니다. 
- [x] 러닝 스케줄 참여 API
  - 러닝 스케줄에 참여 등록합니다. 
  - 이때 작성자 참여 예외, 중복 참여 예외 등의 예외를 처리합니다.  
- [x] 러닝 스케줄 참여 취소 API
  - 러닝 스케출 참여를 취소합니다. 
  - 이때 작성자 취소 예외, 중복 취소 예외 등의 예외를 처리합니다. 
- [x] 사용자 러닝 스케줄 조회 API (마이페이지)
  - 사용자가 참여 신청한 러닝 스케줄과 작성한 스케줄을 조회합니다. 
  - 이때 오늘 이후 날짜의 러닝 스케줄만 조회합니다. 
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #15 

<br><br>