### PR TITLE
러닝 기능 리팩토링

### DIFF
--- a/src/main/java/com/runningduk/unirun/api/message/SummeryMessage.java
+++ b/src/main/java/com/runningduk/unirun/api/message/SummeryMessage.java
@@ -10,9 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class SummeryMessage {
-    private String date;
-    private String dayOfWeek;
-    private String time;
     private double distance;
     private double cal;
     private int runningDataId;


### PR DESCRIPTION
## 요약 

러닝 기능 리팩토링을 진행했습니다. 

<br><br>

## 작업 내용 
- 러닝 완료 시 띄우는 날짜, 요일, 총 러닝 시간 데이터는 프론트에서 처리
  - 서버의 부하를 줄이기 위해 프론트에서 처리하는 것이 좋다고 판단
  - 사용자가 버튼을 누를 때마다 바로 시간을 측정할 수 있기 때문에 실시간으로 반응하는 사용자 경험 제공 가능 
- 러닝 완료 시 프론트에서 백으로 총 러닝 시간 데이터 전송

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #19

<br><br>