### PR TITLE
러닝 타입 조회 버그 

### DIFF
--- a/src/main/java/com/runningduk/unirun/api/controller/LoginController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/LoginController.java
@@ -1,4 +1,0 @@
-package com.runningduk.unirun.api.controller;
-
-public class LoginController {
-}

--- a/src/main/java/com/runningduk/unirun/api/controller/LoginController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/LoginController.java
@@ -1,0 +1,4 @@
+package com.runningduk.unirun.api.controller;
+
+public class LoginController {
+}

--- a/src/main/java/com/runningduk/unirun/api/controller/RunningTypeController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/RunningTypeController.java
@@ -17,10 +17,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @RestController
@@ -44,6 +46,13 @@ public class RunningTypeController {
 
         rsList.addAll(attendedSchedule);
         rsList.addAll(createdSchedules);
+
+        LocalDate today = LocalDate.now();
+
+        // 오늘 날짜의 러닝 스케줄만 필터링
+        rsList = rsList.stream()
+                .filter(runningSchedule -> runningSchedule.getRunningDate().toLocalDate().equals(today))
+                .collect(Collectors.toList());
 
         List<RunningTypeGetRes> typeNames = new ArrayList<>();
         typeNames.add(new RunningTypeGetRes("직접 입력"));

--- a/src/main/java/com/runningduk/unirun/api/controller/RunningTypeController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/RunningTypeController.java
@@ -114,6 +114,16 @@ public class RunningTypeController {
                     .data(null)
                     .message("러닝 이름 저장에 실패하였습니다.")
                     .build().toEntity(httpStatus);
+        } catch (Exception e) {
+            log.error("Failed to add running name", e);
+
+            httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+
+            return CommonApiResponse.builder()
+                    .statusCode(httpStatus.value())
+                    .data(null)
+                    .message("An internal server error occurred. Please try again later.")
+                    .build().toEntity(httpStatus);
         }
     }
 }


### PR DESCRIPTION
## 요약 
러닝 완료 직후 팝업으로 뜨는 러닝 완료 알림 기능에 관한 버그

<br><br>

## 작업 내용 
- 러닝 완료 후, 러닝 타입을 조회할 때 **당일 러닝 스케줄**의 러닝 타입만 조회되도록 수정
- 러닝 이름 저장 API에서 서버 에러에 대한 예외 처리 추가

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #16 

<br><br>