### PR TITLE
로그인 여부 Intercepter 적용 

### DIFF
--- a/src/main/java/com/runningduk/unirun/api/controller/CalendarController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/CalendarController.java
@@ -94,16 +94,6 @@ public class CalendarController {
         try {
             String userId = (String) session.getAttribute("userId");
 
-            if (userId == null) {
-                httpStatus = HttpStatus.UNAUTHORIZED;
-
-                return CommonApiResponse.builder()
-                        .statusCode(httpStatus.value())
-                        .data(null)
-                        .message("Login is required.")
-                        .build().toEntity(httpStatus);
-            }
-
             List<MyRunningSchedulesGetRes> runningScheduleList = new ArrayList<>();
 
             List<RunningSchedule> userCreatedSchedules = runningScheduleService.getRunningScheduleListByUserId(userId);
@@ -156,15 +146,6 @@ public class CalendarController {
     public ResponseEntity<CommonApiResponse> handleDeleteRunningSchedule(@PathVariable(name="runningScheduleId") int runningScheduleId, HttpSession httpSession) {
         try {
             String userId = (String) httpSession.getAttribute("userId");
-            if (userId == null) {
-                httpStatus = HttpStatus.UNAUTHORIZED;
-
-                return CommonApiResponse.builder()
-                        .statusCode(httpStatus.value())
-                        .data(null)
-                        .message("Login is required.")
-                        .build().toEntity(httpStatus);
-            }
 
             RunningSchedule runningSchedule = runningScheduleService.getRunningScheduleById(runningScheduleId);
             if (!runningSchedule.getUserId().equals(userId)) {
@@ -213,15 +194,6 @@ public class CalendarController {
     public ResponseEntity<CommonApiResponse> handleAttendRunningSchedule(@PathVariable(name="runningScheduleId") int runningScheduleId, HttpSession httpSession) {
         try {
             String userId = (String) httpSession.getAttribute("userId");
-            if (userId == null) {
-                httpStatus = HttpStatus.UNAUTHORIZED;
-
-                return CommonApiResponse.builder()
-                        .statusCode(httpStatus.value())
-                        .data(null)
-                        .message("Login is required.")
-                        .build().toEntity(httpStatus);
-            }
 
             attendanceService.attendRunningSchedule(runningScheduleId, userId);
 
@@ -269,15 +241,6 @@ public class CalendarController {
     public ResponseEntity<CommonApiResponse> handleUnattendRunningSchedule(@PathVariable(name="runningScheduleId") int runningScheduleId, HttpSession httpSession) {
         try {
             String userId = (String) httpSession.getAttribute("userId");
-            if (userId == null) {
-                httpStatus = HttpStatus.UNAUTHORIZED;
-
-                return CommonApiResponse.builder()
-                        .statusCode(httpStatus.value())
-                        .data(null)
-                        .message("Login is required.")
-                        .build().toEntity(httpStatus);
-            }
 
             attendanceService.unattendRunningSchedule(runningScheduleId, userId);
 
@@ -335,15 +298,6 @@ public class CalendarController {
     public ResponseEntity<CommonApiResponse> handlePostRunningSchedule(@Valid @RequestBody RunningSchedulePostReq req, BindingResult bindingResult, HttpSession httpSession) {
         try {
             String userId = (String) httpSession.getAttribute("userId");
-            if (userId == null) {
-              httpStatus = HttpStatus.UNAUTHORIZED;
-
-                return CommonApiResponse.builder()
-                        .statusCode(httpStatus.value())
-                        .data(null)
-                        .message("Login is required.")
-                        .build().toEntity(httpStatus);
-            }
 
             if (bindingResult.hasErrors()) {
                 log.error("Failed to post running schedule");

--- a/src/main/java/com/runningduk/unirun/api/controller/MyRunningController.java
+++ b/src/main/java/com/runningduk/unirun/api/controller/MyRunningController.java
@@ -3,6 +3,7 @@ package com.runningduk.unirun.api.controller;
 import com.runningduk.unirun.api.response.CommonApiResponse;
 import com.runningduk.unirun.api.service.RunningDataService;
 import com.runningduk.unirun.domain.entity.RunningData;
+import com.runningduk.unirun.domain.entity.RunningSchedule;
 import com.runningduk.unirun.exceptions.NoSuchRunningDataException;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -57,8 +58,22 @@ public class MyRunningController {
     }
 
     @DeleteMapping("/{runningDataId}")
-    public ResponseEntity<CommonApiResponse> deleteRunningData(@PathVariable int runningDataId) {
+    public ResponseEntity<CommonApiResponse> deleteRunningData(@PathVariable int runningDataId, HttpSession httpSession) {
         try {
+            String userId = (String) httpSession.getAttribute("userId");
+
+            RunningData runningData = runningDataService.getRunningDataById(runningDataId);
+
+            if (runningData.getUserId().equals(userId)) {
+                httpStatus = HttpStatus.UNAUTHORIZED;
+
+                return CommonApiResponse.builder()
+                        .statusCode(httpStatus.value())
+                        .data(null)
+                        .message("You do not have permission to delete this running data.")
+                        .build().toEntity(httpStatus);
+            }
+
             runningDataService.deleteRunningDataById(runningDataId);
 
             log.info("Successfully deleted running data list for runningDataId {}", runningDataId);

--- a/src/main/java/com/runningduk/unirun/config/CorsConfig.java
+++ b/src/main/java/com/runningduk/unirun/config/CorsConfig.java
@@ -46,7 +46,7 @@ public class CorsConfig implements WebMvcConfigurer {
         registry.addInterceptor(new LoginCheckInterceptor()) //LoginCheckInterceptor 등록
                 .order(1)
                 .addPathPatterns("/**")
-                .excludePathPatterns("/", "/user/auth", "/user/register","/running/**");
+                .excludePathPatterns("/", "/user/auth", "/user/register", "/calendar/running-schedules/monthly", "/calendar/running-schedules/daily");
     }
 
 }


### PR DESCRIPTION
## 요약 
코드 중복을 방지하기 위해 Controller 내부 로그인 여부 코드를 Intercepter로 대체합니다. 

<br><br>

## 작업 내용 
- Configuration을 이용하여 로그인 여부 Intercepter를 API에 적용
- Controller에 중복된 로그인 여부 확인 코드를 삭제
- 당사자만 러닝 데이터를 삭제할 수 있도록 수정 

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #25 

<br><br>