### PR TITLE
Session에 Redis 사용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'com.google.code.gson:gson:2.7'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
-  implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -40,6 +40,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springframework.session:spring-session-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 }
 

--- a/src/main/java/com/runningduk/unirun/config/RedisConfig.java
+++ b/src/main/java/com/runningduk/unirun/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.runningduk.unirun.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
+        redisConfiguration.setHostName(redisHost);
+        redisConfiguration.setPort(redisPort);
+        redisConfiguration.setPassword(password);
+        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisConfiguration);
+
+        return lettuceConnectionFactory;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ jasypt:
   encryptor:
     bean: jasyptEncryptor
     key:
-sever:
+server:
   servlet:
     session:
       cookie:
@@ -20,6 +20,12 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update  # ddl-auto 설정 추가
+  session:
+    store-type: redis
+  redis:
+    host: redis-19960.c340.ap-northeast-2-1.ec2.redns.redis-cloud.com
+    port: 19960
+    password: # 노션 참고하여 redis password 작성 후 실행
 swagger:
   title: unirun
   version: v1.0


### PR DESCRIPTION
## 요약 
두 서버 간의 세션 공유를 위해 Session에 Redis를 사용합니다. 
<br><br>

## 작업 내용 
- Session에 Redis를 사용하기 위한 설정 작업을 진행했습니다. 

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #29 
<br><br>